### PR TITLE
Fix development mode regression & add 'passive' queue option

### DIFF
--- a/rabbitmq_pika_flask/QueueParams.py
+++ b/rabbitmq_pika_flask/QueueParams.py
@@ -5,8 +5,10 @@ class QueueParams:
     durable: bool
     auto_delete: bool
     exclusive: bool
+    passive: bool
 
-    def __init__(self, durable=True, auto_delete=False,  exclusive=False) -> None:
+    def __init__(self, durable=True, auto_delete=False, exclusive=False, passive=False) -> None:
         self.durable = durable
         self.auto_delete = auto_delete
         self.exclusive = exclusive
+        self.passive = passive

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -154,8 +154,8 @@ class RabbitMQ:
 
         if self.development:
             self.queue_prefix = "dev." + str(uuid4()) + queue_prefix
-            self.queue_params = QueueParams(False, True, True)
-            self.exchange_params = ExchangeParams(False, True, False)
+            self.queue_params = QueueParams(durable=False, auto_delete=True, exclusive=False)
+            self.exchange_params = ExchangeParams(passive=False, durable=False, auto_delete=True, internal=False)
         else:
             # Avoiding running twice when flask in debug mode
             self._validate_connection()

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -154,7 +154,7 @@ class RabbitMQ:
 
         if self.development:
             self.queue_prefix = "dev." + str(uuid4()) + queue_prefix
-            self.queue_params = QueueParams(durable=False, auto_delete=True, exclusive=False)
+            self.queue_params = QueueParams(durable=False, auto_delete=True, exclusive=False, passive=False)
             self.exchange_params = ExchangeParams(passive=False, durable=False, auto_delete=True, internal=False)
         else:
             # Avoiding running twice when flask in debug mode
@@ -344,6 +344,7 @@ class RabbitMQ:
 
         channel.queue_declare(
             queue_name,
+            passive=self.queue_params.passive,
             durable=self.queue_params.durable,
             auto_delete=self.queue_params.auto_delete,
             exclusive=self.queue_params.exclusive,

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -156,7 +156,8 @@ class RabbitMQ:
             self.queue_prefix = "dev." + str(uuid4()) + queue_prefix
             self.queue_params = QueueParams(durable=False, auto_delete=True, exclusive=False, passive=False)
             self.exchange_params = ExchangeParams(passive=False, durable=False, auto_delete=True, internal=False)
-        else:
+
+        if not self.development or os.getenv("WERKZEUG_RUN_MAIN") == "true":
             # Avoiding running twice when flask in debug mode
             self._validate_connection()
 
@@ -199,7 +200,7 @@ class RabbitMQ:
 
         def decorator(f):
             # ignore flask default reload when on debug mode
-            if not self.development:
+            if not self.development or os.getenv("WERKZEUG_RUN_MAIN") == "true":
                 nonlocal props_needed
                 if props_needed is None:
                     f_signature = inspect.signature(f).parameters


### PR DESCRIPTION
Sorry for missing these before...

EDIT: @rafaelclp I've added another commit that fixes a huge regression when running in development mode. We also need to evaluate 'WERKZEUG_RUN_MAIN' when doing initialization, because this can also be 'true' in development mode, so we can't blindly do the checks on the development mode status alone.