### PR TITLE
Changing delivery mode default to persist on send messages

### DIFF
--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -442,6 +442,8 @@ class RabbitMQ:
                 properties["message_id"] = sha256(json.dumps(body).encode("utf-8")).hexdigest()
             if "timestamp" not in properties:
                 properties["timestamp"] = int(datetime.now().timestamp())
+            if "delivery_mode" not in properties:
+                properties["delivery_mode"]=spec.PERSISTENT_DELIVERY_MODE
 
             if "headers" not in properties:
                 properties["headers"] = {}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.33",
+    version="1.2.34",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
Proposal for New Version 1.2.23

In the constructor, set **default_send_properties** to pass properties that we want to define for all messages.

Motive:
All queues are currently set to durable, while our messages are not in persistent delivery mode. These changes ensure that the messages we send will recover in the event of a service failure.

Usage:
```
RabbitMQ(default_send_properties={"delivery_mode":2})
```