### PR TITLE
Fix typing

### DIFF
--- a/rabbitmq_pika_flask/RabbitConsumerMiddleware.py
+++ b/rabbitmq_pika_flask/RabbitConsumerMiddleware.py
@@ -46,7 +46,9 @@ def call_middlewares(
             middleware = next(middlewares_iter)
         except StopIteration as e:
             # We can't be 100% sure which middleware did this
-            raise RabbitConsumerMiddlewareError("Middleware called `call_next` twice.")
+            raise RabbitConsumerMiddlewareError(
+                "Middleware called `call_next` twice."
+            ) from e
         middleware(message, call_next)
 
     call_next(message)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.34",
+    version="1.2.35",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
This fixes typing, such that `pyright` returns no errors.

I also restored compatibility with Python 3.8 (by converting `Dict` to `dict`, for example). I don't know whether it works with older versions - py<=3.7 have reached EOF.