### PR TITLE
Remove support for EOL python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,6 @@ setup(
         "License :: OSI Approved :: MIT License",  # Again, pick a license
         # Specify which pyhton versions that you want to support
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Those have all reached end-of-life: https://devguide.python.org/versions/

I'm not adding 3.11 and 3.12 because I haven't tested in those. No idea if the required libs all work in those newer versions or need updating.