### PR TITLE
Support custom dead letter exchange params

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.35",
+    version="1.2.36",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
Since we support this for the main exchange, it makes sense to support it for the dead letter exchange. We'll use these params to set up a durable dead letter exchange.